### PR TITLE
Minor fix for scroll when OptSpaceInitial > 0

### DIFF
--- a/attabs/attabs.pas
+++ b/attabs/attabs.pas
@@ -3659,7 +3659,7 @@ procedure TATTabs.DoPaintUserButtons(C: TCanvas; const AButtons: TATTabButtons; 
 var
   BtnId: TATTabButton;
   ElemType: TATTabElemType;
-  NIndex, i, FTabHeight: integer;
+  NIndex, i: integer;
   R: TRect;
 begin
   for i:= 0 to Length(AButtons)-1 do
@@ -3669,11 +3669,7 @@ begin
     //in that small area before the first userbutton:
     if FOptPosition in [atpTop, atpBottom] then
     begin
-      FTabHeight := ClientHeight;
-      if FOptMultiline then
-        FTabHeight:= R.Bottom+FOptSpacer2;
-
-      R:=Rect(0,0,OptSpaceInitial, FTabHeight);
+      R:=Rect(0,0,OptSpaceInitial, FOptTabHeight);
       DoPaintBgTo(C, R);
     end;
 

--- a/attabs/attabs.pas
+++ b/attabs/attabs.pas
@@ -22,7 +22,7 @@ uses
   Windows,
   {$endif}
   Classes, Types, Graphics,
-  Controls, Messages, UITypes, //ImgList, ImgList is deprecated, suppress compiler warning and may need compile conditional here
+  Controls, Messages, ImgList,
   {$ifdef FPC}
   InterfaceBase,
   LCLIntf,
@@ -2183,7 +2183,7 @@ begin
     RRect:= GetTabRect(i);
     GetTabXProps(i, RRect, NColorXBg, NColorXBorder, NColorXMark, bMouseOverX, RectX);
 
-    //bMouseOver:= i=FTabIndexOver;
+    bMouseOver:= i=FTabIndexOver;
     bShowX:= IsShowX(i);
 
     if IsPaintNeeded(aeTabActive, i, C, RRect) then

--- a/attabs/attabs.pas
+++ b/attabs/attabs.pas
@@ -22,7 +22,7 @@ uses
   Windows,
   {$endif}
   Classes, Types, Graphics,
-  Controls, Messages, ImgList,
+  Controls, Messages, UITypes, //ImgList, ImgList is deprecated, suppress compiler warning and may need compile conditional here
   {$ifdef FPC}
   InterfaceBase,
   LCLIntf,
@@ -2183,7 +2183,7 @@ begin
     RRect:= GetTabRect(i);
     GetTabXProps(i, RRect, NColorXBg, NColorXBorder, NColorXMark, bMouseOverX, RectX);
 
-    bMouseOver:= i=FTabIndexOver;
+    //bMouseOver:= i=FTabIndexOver;
     bShowX:= IsShowX(i);
 
     if IsPaintNeeded(aeTabActive, i, C, RRect) then
@@ -2687,7 +2687,13 @@ var
   Data: TATTabData;
 begin
   inherited;
-  if TabCount=0 then exit;
+
+  if TabCount=0 then
+  begin
+    Invalidate; //cleans up <> v and x highlights if no tabs
+    exit;
+  end;
+
   FTabIndexOver:= GetTabAt(X, Y, IsX);
   FTabIndexDrop:= FTabIndexOver;
   Data:= nil;
@@ -3524,7 +3530,7 @@ var
   ElemType: TATTabElemType;
   R: TRect;
 begin
-  bOver:= FTabIndexOver=cTabIndexArrowScrollLeft;
+  bOver:= (TabCount > 0) and (FTabIndexOver=cTabIndexArrowScrollLeft);
   if bOver then
     ElemType:= aeArrowScrollLeftOver
   else
@@ -3552,7 +3558,7 @@ var
   ElemType: TATTabElemType;
   R: TRect;
 begin
-  bOver:= FTabIndexOver=cTabIndexArrowScrollRight;
+  bOver:= (TabCount > 0) and (FTabIndexOver=cTabIndexArrowScrollRight);
   if bOver then
     ElemType:= aeArrowScrollRightOver
   else
@@ -3658,6 +3664,15 @@ var
 begin
   for i:= 0 to Length(AButtons)-1 do
   begin
+
+    //If we have an OptSpaceInitial > 0 then this "hides" scrolled buttons
+    //in that small area before the first userbutton:
+    if FOptPosition in [atpTop, atpBottom] then
+    begin
+      R:=Rect(0,0,OptSpaceInitial,ClientHeight);
+      DoPaintBgTo(C, R);
+    end;
+
     BtnId:= AButtons[i].Id;
     R:= GetRectOfButtonIndex(i, AtLeft);
 

--- a/attabs/attabs.pas
+++ b/attabs/attabs.pas
@@ -3659,7 +3659,7 @@ procedure TATTabs.DoPaintUserButtons(C: TCanvas; const AButtons: TATTabButtons; 
 var
   BtnId: TATTabButton;
   ElemType: TATTabElemType;
-  NIndex, i: integer;
+  NIndex, i, FTabHeight: integer;
   R: TRect;
 begin
   for i:= 0 to Length(AButtons)-1 do
@@ -3669,7 +3669,11 @@ begin
     //in that small area before the first userbutton:
     if FOptPosition in [atpTop, atpBottom] then
     begin
-      R:=Rect(0,0,OptSpaceInitial,ClientHeight);
+      FTabHeight := ClientHeight;
+      if FOptMultiline then
+        FTabHeight:= R.Bottom+FOptSpacer2;
+
+      R:=Rect(0,0,OptSpaceInitial, FTabHeight);
       DoPaintBgTo(C, R);
     end;
 


### PR DESCRIPTION
Small issue: I found that if OptSpaceInitial is > 0 and the tabs are scrollable, I was seeing the tabs in the little area from the left of the tab client area to the width of the OptSpaceInitial setting.

Also a couple of minor visual fixes and a few fixes to supress some compiler warnings.