### PR TITLE
Fix missing system ui types

### DIFF
--- a/attabs/attabs.pas
+++ b/attabs/attabs.pas
@@ -25,6 +25,7 @@ uses
   {$endif}
   Classes, Types, Graphics,
   Controls, Messages, ImgList,
+  System.UITypes,
   {$ifdef FPC}
   InterfaceBase,
   LCLIntf,


### PR DESCRIPTION
I get numerous warning in Delphi, because of this missing unit.