### PR TITLE
Added two new events: OnTabDropQuery and OnTabDblClick

### DIFF
--- a/attabs/attabs.pas
+++ b/attabs/attabs.pas
@@ -185,6 +185,8 @@ type
   TATTabClickUserButton = procedure (Sender: TObject; AIndex: integer) of object;
   TATTabGetTickEvent = function (Sender: TObject; ATabObject: TObject): Int64 of object;
   TATTabGetCloseActionEvent = procedure (Sender: TObject; var AAction: TATTabActionOnClose) of object;
+  TATTabDblClickEvent = procedure (Sender: TObject; AIndex: integer) of object;
+  TATTabDropQueryEvent = procedure (Sender: TObject; NFrom, Nto: integer; var ACanDrop: boolean) of object;
 
 type
   TATTabTriangle = (
@@ -520,6 +522,8 @@ type
     FOnTabChangeQuery: TATTabChangeQueryEvent;
     FOnTabGetTick: TATTabGetTickEvent;
     FOnTabGetCloseAction: TATTabGetCloseActionEvent;
+    FOnTabDblClick: TATTabDblClickEvent;
+    FOnTabDropQuery: TATTabDropQueryEvent;
 
     function ConvertButtonIdToTabIndex(Id: TATTabButton): integer; inline;
     procedure DoAnimationTabAdd(AIndex: integer);
@@ -834,6 +838,8 @@ type
     property OnTabChangeQuery: TATTabChangeQueryEvent read FOnTabChangeQuery write FOnTabChangeQuery;
     property OnTabGetTick: TATTabGetTickEvent read FOnTabGetTick write FOnTabGetTick;
     property OnTabGetCloseAction: TATTabGetCloseActionEvent read FOnTabGetCloseAction write FOnTabGetCloseAction;
+    property OnTabDblClick: TATTabDblClickEvent read FOnTabDblClick write FOnTabDblClick;
+    property OnTabDropQuery: TATTabDropQueryEvent read FOnTabDropQuery write FOnTabDropQuery;
   end;
 
 var
@@ -2841,6 +2847,9 @@ begin
   
   if IsDblClick then
   begin
+    if Assigned(FOnTabDblClick) and (FTabIndexOver>=0) then
+      FOnTabDblClick(Self, FTabIndexOver);
+
     if FOptMouseDoubleClickClose and (FTabIndexOver>=0) then
       DeleteTab(FTabIndexOver, true, true)
     else
@@ -3501,13 +3510,19 @@ end;
 procedure TATTabs.DoTabDrop;
 var
   NFrom, NTo: integer;
+  ACanDrop: boolean;
 begin
   NFrom:= FTabIndex;
   if not IsIndexOk(NFrom) then Exit;
   NTo:= FTabIndexDrop;
   if not IsIndexOk(NTo) then
     NTo:= TabCount-1;
-  if NFrom=NTo then Exit;  
+  if NFrom=NTo then Exit;
+
+  ACanDrop:= true;
+  if Assigned(FOnTabDropQuery) then
+    FOnTabDropQuery(Self, NFrom, NTo, ACanDrop);
+  if not ACanDrop then Exit;
 
   FTabList.Items[NFrom].Index:= NTo;
   SetTabIndex(NTo);


### PR DESCRIPTION
OnTabDropQuery allows you to prevent drop operations, if you need to do so and also allow you to access TabData for old/new position of moved tab.
OnTabDblClick is needed if you want to show some UI in a double click event. With the standard OnDblClick event the control will get into a constant drag mode, which can't be canceled. Moreover this new event is fired only for double click events over tabs, providing `tabIndex`, making it easier to work with. It is called where TATTabs does other double-click related work, so it is consistent with the current codebase.